### PR TITLE
Add cached tokens usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 - [Support Us](#support-us)
 - [Get Started](#get-started)
 - [Usage](#usage)
-  - [Completions Resource](#completions-resource)
   - [Messages Resource](#messages-resource)
+  - [Completions Resource (Legacy)](#completions-resource-legacy)
 - [Meta Information](#meta-information)
 - [Troubleshooting](#troubleshooting)
 - [Testing](#testing)
@@ -82,52 +82,6 @@ $client = Anthropic::factory()
 
 ## Usage
 
-### `Completions` Resource
-
-#### `create`
-
-Creates a completion for the provided prompt and parameters.
-
-```php
-$response = $client->completions()->create([
-    'model' => 'claude-2.1',
-    'prompt' => '\n\nHuman: Hello, Claude\n\nAssistant:',
-    'max_tokens_to_sample' => 100,
-    'temperature' => 0
-]);
-
-$response->type; // 'completion'
-$response->id; // 'compl_01EKm5HZ9y6khqaSZjsX44fS'
-$response->completion; // ' Hello! Nice to meet you.'
-$response->stop_reason; // 'stop_sequence'
-$response->model; // 'claude-2.1'
-$response->stop; // '\n\nHuman:'
-$response->log_id; // 'compl_01EKm5HZ9y6khqaSZjsX44fS'
-
-$response->toArray(); // ['id' => 'compl_01EKm5HZ9y6khqaSZjsX44fS', ...]
-```
-
-#### `create streamed`
-
-Creates a streamed completion for the provided prompt and parameters.
-
-```php
-$stream = $client->completions()->createStreamed([
-    'model' => 'claude-2.1',
-    'prompt' => 'Hi',
-    'max_tokens_to_sample' => 70,
-]);
-
-foreach($stream as $response){
-    $response->completion;
-}
-// 1. iteration => 'I'
-// 2. iteration => ' am'
-// 3. iteration => ' very'
-// 4. iteration => ' excited'
-// ...
-```
-
 ### `Messages` Resource
 
 #### `create`
@@ -157,6 +111,8 @@ foreach ($response->content as $result) {
 
 $response->usage->inputTokens; // 10,
 $response->usage->outputTokens; // 19,
+$response->usage->cacheCreationInputTokens; // 0,
+$response->usage->cacheReadInputTokens; // 0,
 
 $response->toArray(); // ['id' => 'msg_01BSy0WCV7QR2adFBauynAX7', ...]
 ```
@@ -211,6 +167,8 @@ $response->content[1]->input['unit']; // 'fahrenheit'
 
 $response->usage->inputTokens; // 448,
 $response->usage->outputTokens; // 87,
+$response->usage->cacheCreationInputTokens; // 0,
+$response->usage->cacheReadInputTokens; // 0,
 
 $response->toArray(); // ['id' => 'msg_01BSy0WCV7QR2adFBauynAX7', ...]
 ```
@@ -407,6 +365,52 @@ foreach($stream as $response){
         'output_tokens' => 12,
     ]
 ]
+```
+
+### `Completions` Resource (Legacy)
+
+#### `create`
+
+Creates a completion for the provided prompt and parameters.
+
+```php
+$response = $client->completions()->create([
+    'model' => 'claude-2.1',
+    'prompt' => '\n\nHuman: Hello, Claude\n\nAssistant:',
+    'max_tokens_to_sample' => 100,
+    'temperature' => 0
+]);
+
+$response->type; // 'completion'
+$response->id; // 'compl_01EKm5HZ9y6khqaSZjsX44fS'
+$response->completion; // ' Hello! Nice to meet you.'
+$response->stop_reason; // 'stop_sequence'
+$response->model; // 'claude-2.1'
+$response->stop; // '\n\nHuman:'
+$response->log_id; // 'compl_01EKm5HZ9y6khqaSZjsX44fS'
+
+$response->toArray(); // ['id' => 'compl_01EKm5HZ9y6khqaSZjsX44fS', ...]
+```
+
+#### `create streamed`
+
+Creates a streamed completion for the provided prompt and parameters.
+
+```php
+$stream = $client->completions()->createStreamed([
+    'model' => 'claude-2.1',
+    'prompt' => 'Hi',
+    'max_tokens_to_sample' => 70,
+]);
+
+foreach($stream as $response){
+    $response->completion;
+}
+// 1. iteration => 'I'
+// 2. iteration => ' am'
+// 3. iteration => ' very'
+// 4. iteration => ' excited'
+// ...
 ```
 
 ## Meta Information

--- a/src/Resources/Messages.php
+++ b/src/Resources/Messages.php
@@ -29,7 +29,7 @@ final class Messages implements MessagesContract
 
         $payload = Payload::create('messages', $parameters);
 
-        /** @var Response<array{id: string, type: string, role: string, model: string, stop_sequence: string|null, usage: array{input_tokens: int, output_tokens: int}, content: array<int, array{type: string, text?: string|null, id?: string, name?: string, input?: array<string, string>}>, stop_reason: string}> $response */
+        /** @var Response<array{id: string, type: string, role: string, model: string, stop_sequence: string|null, usage: array{input_tokens: int, output_tokens: int, cache_creation_input_tokens: int, cache_read_input_tokens: int}, content: array<int, array{type: string, text?: string|null, id?: string, name?: string, input?: array<string, string>}>, stop_reason: string}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return CreateResponse::from($response->data(), $response->meta());

--- a/src/Responses/Messages/CreateResponse.php
+++ b/src/Responses/Messages/CreateResponse.php
@@ -12,12 +12,12 @@ use Anthropic\Responses\Meta\MetaInformation;
 use Anthropic\Testing\Responses\Concerns\Messages\Fakeable;
 
 /**
- * @implements ResponseContract<array{id: string, type: string, role: string, model: string, stop_sequence: string|null, usage: array{input_tokens: int, output_tokens: int}, content: array<int, array{type: string, text?: string|null, id?: string|null, name?: string|null, input?: array<string, string>|null}>, stop_reason: string}>
+ * @implements ResponseContract<array{id: string, type: string, role: string, model: string, stop_sequence: string|null, usage: array{input_tokens: int, output_tokens: int, cache_creation_input_tokens: int, cache_read_input_tokens: int}, content: array<int, array{type: string, text?: string|null, id?: string|null, name?: string|null, input?: array<string, string>|null}>, stop_reason: string}>
  */
 final class CreateResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{id: string, type: string, role: string, model: string, stop_sequence: string|null, usage: array{input_tokens: int, output_tokens: int}, content: array<int, array{type: string, text?: string|null, id?: string|null, name?: string|null, input?: array<string, string>|null}>, stop_reason: string}>
+     * @use ArrayAccessible<array{id: string, type: string, role: string, model: string, stop_sequence: string|null, usage: array{input_tokens: int, output_tokens: int, cache_creation_input_tokens: int, cache_read_input_tokens: int}, content: array<int, array{type: string, text?: string|null, id?: string|null, name?: string|null, input?: array<string, string>|null}>, stop_reason: string}>
      */
     use ArrayAccessible;
 
@@ -42,7 +42,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: string, type: string, role: string, model: string, stop_sequence: string|null, usage: array{input_tokens: int, output_tokens: int}, content: array<int, array{type: string, text?: string|null, id?: string|null, name?: string|null, input?: array<string, string>|null}>, stop_reason: string}  $attributes
+     * @param  array{id: string, type: string, role: string, model: string, stop_sequence: string|null, usage: array{input_tokens: int, output_tokens: int, cache_creation_input_tokens: int|null, cache_read_input_tokens: int|null}, content: array<int, array{type: string, text?: string|null, id?: string|null, name?: string|null, input?: array<string, string>|null}>, stop_reason: string}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {

--- a/src/Responses/Messages/CreateResponseUsage.php
+++ b/src/Responses/Messages/CreateResponseUsage.php
@@ -9,27 +9,33 @@ final class CreateResponseUsage
     private function __construct(
         public readonly int $inputTokens,
         public readonly int $outputTokens,
+        public readonly int $cacheCreationInputTokens,
+        public readonly int $cacheReadInputTokens,
     ) {}
 
     /**
-     * @param  array{input_tokens: int, output_tokens: int}  $attributes
+     * @param  array{input_tokens: int, cache_creation_input_tokens: int|null, cache_read_input_tokens: int|null, output_tokens: int}  $attributes
      */
     public static function from(array $attributes): self
     {
         return new self(
             $attributes['input_tokens'],
             $attributes['output_tokens'],
+            $attributes['cache_creation_input_tokens'] ?? 0,
+            $attributes['cache_read_input_tokens'] ?? 0,
         );
     }
 
     /**
-     * @return array{input_tokens: int, output_tokens: int}
+     * @return array{input_tokens: int, output_tokens: int, cache_creation_input_tokens: int, cache_read_input_tokens: int}
      */
     public function toArray(): array
     {
         return [
             'input_tokens' => $this->inputTokens,
             'output_tokens' => $this->outputTokens,
+            'cache_creation_input_tokens' => $this->cacheCreationInputTokens,
+            'cache_read_input_tokens' => $this->cacheReadInputTokens,
         ];
     }
 }

--- a/tests/Helpers/Message.php
+++ b/tests/Helpers/Message.php
@@ -14,6 +14,32 @@ function messagesCompletion(): array
         'usage' => [
             'input_tokens' => 10,
             'output_tokens' => 20,
+            'cache_creation_input_tokens' => 0,
+            'cache_read_input_tokens' => 0,
+        ],
+        'content' => [
+            [
+                'type' => 'text',
+                'text' => "Hello! I'm Claude, an AI assistant. How can I help you today?",
+            ],
+        ],
+        'stop_reason' => 'end_turn',
+    ];
+}
+
+function messagesCompletionWithCache(): array
+{
+    return [
+        'id' => 'msg_019hiOHAEXQwq1PTeETNEBWe',
+        'type' => 'message',
+        'role' => 'assistant',
+        'model' => 'claude-3-opus-20240229',
+        'stop_sequence' => null,
+        'usage' => [
+            'input_tokens' => 10,
+            'output_tokens' => 20,
+            'cache_creation_input_tokens' => 30,
+            'cache_read_input_tokens' => 40,
         ],
         'content' => [
             [

--- a/tests/Responses/Messages/CreateResponseUsage.php
+++ b/tests/Responses/Messages/CreateResponseUsage.php
@@ -7,7 +7,19 @@ test('from', function () {
 
     expect($result)
         ->inputTokens->toBe(10)
-        ->outputTokens->toBe(20);
+        ->outputTokens->toBe(20)
+        ->cacheCreationInputTokens->toBe(0)
+        ->cacheReadInputTokens->toBe(0);
+});
+
+test('from with cache', function () {
+    $result = CreateResponseUsage::from(messagesCompletionWithCache()['usage']);
+
+    expect($result)
+        ->inputTokens->toBe(10)
+        ->outputTokens->toBe(20)
+        ->cacheCreationInputTokens->toBe(30)
+        ->cacheReadInputTokens->toBe(40);
 });
 
 test('to array', function () {
@@ -15,4 +27,16 @@ test('to array', function () {
 
     expect($result->toArray())
         ->toBe(messagesCompletion()['usage']);
+});
+
+test('to array wit cache', function () {
+    $result = CreateResponseUsage::from(messagesCompletionWithCache()['usage']);
+
+    expect($result->toArray())
+        ->toBe([
+            'input_tokens' => 10,
+            'output_tokens' => 20,
+            'cache_creation_input_tokens' => 30,
+            'cache_read_input_tokens' => 40,
+        ]);
 });


### PR DESCRIPTION
This PR will add the cached token counts (`cache_creation_input_tokens` and `cache_read_input_tokens`) to the response usage